### PR TITLE
Fixes the doubling of videos

### DIFF
--- a/lib/embed_extender.php
+++ b/lib/embed_extender.php
@@ -56,6 +56,7 @@ function embed_extender_parser($input, $view, $context)
 	//Replace video providers with embebed content
 	if(preg_match_all("/$regexp/siU", $input, $matches, PREG_SET_ORDER)){
 		foreach($matches as $match){
+			if(empty($match[3])){ continue; }
 			foreach ($patterns as $pattern){
 				if (preg_match($pattern, $match[2]) > 0){
 					$input = str_replace($match[0], videoembed_create_embed_object($match[2], uniqid('embed_'), $width), $input);


### PR DESCRIPTION
The doubling of videos is caused by incorrect/buggy code in Elgg when it parses content and creates links out of urls.  For some reason it creates empty anchor tags, and occasionally a duplicate link with no text.  The fix checks to make sure the link has clickable text before parsing for an embed.
